### PR TITLE
Changed Rector Version temporary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "rector/rector": "^0.7.0"
+        "rector/rector": "7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4 || ^9.0"


### PR DESCRIPTION
Rector requires `jetbrains/phpstorm-stubs` since v7.2 (9days ago). This package was never installed via clx private packagist before. Therefore I don't have the necessary permissions to install`complex-gmbh/php-zend2rocket-rector` to our clients repo.

To prevent `jetbrains/phpstorm-stubs` to be installed. I am going to temporary downgrade the required Rector version.